### PR TITLE
Scott/mainrefactor

### DIFF
--- a/config.go
+++ b/config.go
@@ -119,7 +119,7 @@ func (c *Config) makeProxies() {
 // pickHost determines the next backend host to forward the request to - according to round-robin
 // It returns an integer, which represents the host's index in config.Backends
 func (c *Config) pickHost() {
-	nextHost = c.NextHost + 1
+	nextHost := c.NextHost + 1
 	if nextHost  >= c.HostCount {
 		c.NextHost = 0
 	} else {

--- a/config.go
+++ b/config.go
@@ -55,6 +55,8 @@ func (c *Config) init(configFile string) {
 	if _, err := toml.DecodeFile(configFile, c); err != nil {
 		log.Fatal(err)
 	}
+	c.handleUserInput()
+	c.printConfigInfo()
 	c.makeProxies()
 }
 

--- a/config.go
+++ b/config.go
@@ -28,10 +28,13 @@ type Config struct {
 	// Path to private key file related to certificate
 	Keyfile string `toml:keyFile`
 
+	// Revserse Proxies to forward requests to
 	Proxies []*httputil.ReverseProxy
 
+	// Number of proxies available
 	HostCount int
 
+	// The index of the next proxy to forward a request to
 	NextHost int
 }
 
@@ -67,6 +70,7 @@ func (c *Config) init(configFile string) {
 
 // handleUserInput checks command line input and overrides config file settings
 // Backends is parsed from a raw string to a slice of strings
+// TODO: Better input validation
 func (c *Config) handleUserInput() {
 
 	if *backendStr != "" {
@@ -116,7 +120,7 @@ func (c *Config) makeProxies() {
 }
 
 // Function for handling the http requests
-func (c *Config) handle (w http.ResponseWriter, r *http.Request) {
+func (c *Config) handle(w http.ResponseWriter, r *http.Request) {
 	c.pickHost()
 	c.Proxies[c.NextHost].ServeHTTP(w, r)
 }
@@ -125,7 +129,7 @@ func (c *Config) handle (w http.ResponseWriter, r *http.Request) {
 // It returns an integer, which represents the host's index in config.Backends
 func (c *Config) pickHost() {
 	nextHost := c.NextHost + 1
-	if nextHost  >= c.HostCount {
+	if nextHost >= c.HostCount {
 		c.NextHost = 0
 	} else {
 		c.NextHost = nextHost

--- a/config.go
+++ b/config.go
@@ -30,6 +30,10 @@ type Config struct {
 	Keyfile string `toml:keyFile`
 
 	Proxies []*httputil.ReverseProxy
+
+	HostCount int
+
+	NextHost int
 }
 
 // singleton Config instance initially set to nil
@@ -58,6 +62,8 @@ func (c *Config) init(configFile string) {
 	c.handleUserInput()
 	c.printConfigInfo()
 	c.makeProxies()
+	c.HostCount = len(c.Backends)
+	c.NextHost = 0
 }
 
 // handleUserInput checks command line input and overrides config file settings
@@ -112,10 +118,11 @@ func (c *Config) makeProxies() {
 
 // pickHost determines the next backend host to forward the request to - according to round-robin
 // It returns an integer, which represents the host's index in config.Backends
-func (c *Config) pickHost(lastHost, hostCount int) int {
-	x := lastHost + 1
-	if x >= hostCount {
-		return 0
+func (c *Config) pickHost() {
+	nextHost = c.NextHost + 1
+	if nextHost  >= c.HostCount {
+		c.NextHost = 0
+	} else {
+		c.NextHost = nextHost
 	}
-	return x
 }

--- a/config.go
+++ b/config.go
@@ -107,3 +107,13 @@ func (c *Config) makeProxies() {
 		c.Proxies[i] = &httputil.ReverseProxy{Director: director}
 	}
 }
+
+// pickHost determines the next backend host to forward the request to - according to round-robin
+// It returns an integer, which represents the host's index in config.Backends
+func (c *Config) pickHost(lastHost, hostCount int) int {
+	x := lastHost + 1
+	if x >= hostCount {
+		return 0
+	}
+	return x
+}

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ type Config struct {
 // singleton Config instance initially set to nil
 var config *Config = nil
 
-// GetConfig implements a singleton pattern for access the Config instance.
+// GetConfig implements a singleton pattern to access the Config singleton
 func GetConfig(configFile string) *Config {
 	if config == nil {
 		config = new(Config)

--- a/config.go
+++ b/config.go
@@ -19,8 +19,7 @@ type Config struct {
 	// The port the load balancer is bound to
 	Bind string `toml:"bind"`
 
-	// The load balancing mode (i.e. round-robin)
-	// Currently, only round-robin is used, and configurable mode is not supported.
+	// Secure or unsecure http protocol
 	Mode string `toml:"mode"`
 
 	// Path to certificate file
@@ -114,6 +113,12 @@ func (c *Config) makeProxies() {
 		}
 		c.Proxies[i] = &httputil.ReverseProxy{Director: director}
 	}
+}
+
+// Function for handling the http requests
+func (c *Config) handle (w http.ResponseWriter, r *http.Request) {
+	c.pickHost()
+	c.Proxies[c.NextHost].ServeHTTP(w, r)
 }
 
 // pickHost determines the next backend host to forward the request to - according to round-robin

--- a/main.go
+++ b/main.go
@@ -31,7 +31,9 @@ func main() {
 	flag.Parse()
 	config := GetConfig(*configFile)
 
-	http.HandleFunc("/", handle)
+	// send requests to proxies via config.handle
+	http.HandleFunc("/", config.handle)
+
 	// Start the http(s) listener depending on user's selected mode
 	if config.Mode == "http" {
 		http.ListenAndServe(":"+config.Bind, nil)
@@ -41,10 +43,4 @@ func main() {
 		fmt.Fprintf(os.Stderr, "unknown mode or mode not set")
 		os.Exit(1)
 	}
-}
-
-// Function for handling the http requests
-func handle (w http.ResponseWriter, r *http.Request) {
-	config.pickHost()
-	config.Proxies[config.NextHost].ServeHTTP(w, r)
 }

--- a/main.go
+++ b/main.go
@@ -33,8 +33,6 @@ func main() {
 
 	flag.Parse()
 	config := GetConfig(*configFile)
-	config.handleUserInput()
-	config.printConfigInfo()
 	hostCount := len(config.Backends)
 
 	// Function for handling the http requests

--- a/main.go
+++ b/main.go
@@ -36,8 +36,8 @@ func main() {
 
 	// Function for handling the http requests
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		nextHost = config.pickHost(nextHost, config.HostCount)
-		config.Proxies[nextHost].ServeHTTP(w, r)
+		config.pickHost()
+		config.Proxies[config.NextHost].ServeHTTP(w, r)
 	})
 
 	// Start the http(s) listener depending on user's selected mode

--- a/main.go
+++ b/main.go
@@ -16,9 +16,6 @@ import (
 	"os"
 )
 
-// Global variable of the next backend to be sent.  This is for round-robin load balancing
-var nextHost int = 0
-
 // Handling user flags
 // User flags must be package globals they can be easily worked on by Config member functions
 // and avoid passing each command line option as a parameter.

--- a/main.go
+++ b/main.go
@@ -31,12 +31,7 @@ func main() {
 	flag.Parse()
 	config := GetConfig(*configFile)
 
-	// Function for handling the http requests
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		config.pickHost()
-		config.Proxies[config.NextHost].ServeHTTP(w, r)
-	})
-
+	http.HandleFunc("/", handle)
 	// Start the http(s) listener depending on user's selected mode
 	if config.Mode == "http" {
 		http.ListenAndServe(":"+config.Bind, nil)
@@ -46,4 +41,10 @@ func main() {
 		fmt.Fprintf(os.Stderr, "unknown mode or mode not set")
 		os.Exit(1)
 	}
+}
+
+// Function for handling the http requests
+func handle (w http.ResponseWriter, r *http.Request) {
+	config.pickHost()
+	config.Proxies[config.NextHost].ServeHTTP(w, r)
 }

--- a/main.go
+++ b/main.go
@@ -33,11 +33,10 @@ func main() {
 
 	flag.Parse()
 	config := GetConfig(*configFile)
-	hostCount := len(config.Backends)
 
 	// Function for handling the http requests
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		nextHost = config.pickHost(nextHost, hostCount)
+		nextHost = config.pickHost(nextHost, config.HostCount)
 		config.Proxies[nextHost].ServeHTTP(w, r)
 	})
 

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func main() {
 
 	// Function for handling the http requests
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		nextHost = pickHost(nextHost, hostCount)
+		nextHost = config.pickHost(nextHost, hostCount)
 		config.Proxies[nextHost].ServeHTTP(w, r)
 	})
 
@@ -52,14 +52,4 @@ func main() {
 		fmt.Fprintf(os.Stderr, "unknown mode or mode not set")
 		os.Exit(1)
 	}
-}
-
-// pickHost determines the next backend host to forward the request to - according to round-robin
-// It returns an integer, which represents the host's index in config.Backends
-func pickHost(lastHost, hostCount int) int {
-	x := lastHost + 1
-	if x >= hostCount {
-		return 0
-	}
-	return x
 }

--- a/main.go
+++ b/main.go
@@ -35,13 +35,12 @@ func main() {
 	config := GetConfig(*configFile)
 	config.handleUserInput()
 	config.printConfigInfo()
-	proxies := config.makeProxies()
 	hostCount := len(config.Backends)
 
 	// Function for handling the http requests
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		nextHost = pickHost(nextHost, hostCount)
-		proxies[nextHost].ServeHTTP(w, r)
+		config.Proxies[nextHost].ServeHTTP(w, r)
 	})
 
 	// Start the http(s) listener depending on user's selected mode

--- a/main.go
+++ b/main.go
@@ -30,7 +30,6 @@ func main() {
 
 	flag.Parse()
 	config := GetConfig(*configFile)
-
 	// send requests to proxies via config.handle
 	http.HandleFunc("/", config.handle)
 


### PR DESCRIPTION
As part of #40, I needed to do a bit of refactoring so the tests can hit individual units. Namely, I need to roll http.Handlefunc("/", proxy.ServeHttp) into a member function of Config struct. This way, the test framework can specifically call that function and pass in requests. 

Since it refactors quite a bit. I wanted to issue a PR now and get some feedback on the changes. 

What I'd really like to do, is split the Config struct into (a) Config struct, and (b) Prox struct. That should help modularize functionality a bit more. But this is an intermediate step to that goal. Will take some experimentation to get to that. Not sure the architecture will work out.
