### PR TITLE
Add Access Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,17 @@ Subsequent `curl` commands should yield responses from alternating ports (8001 &
 
 ***
 
-##Usage
+## Usage
+
 By default, eps-conduit will bind to port 8000, but any port can be specified.
 
-###Flags
-* -b    list of backend hosts
-  * ex:  eps-conduit -b "10.2.8.1, 10.2.8.2"
-* -bind specify what port to bind to (defaults to 8000)
-  * ex:  eps-conduit -bind 80
-* -mode specifies what mode to use (http or https)
-  * ex:  eps-conduit -mode https
-* -cert specify an SSL cert file (for https mode)
-  * ex:  eps-conduit -cert mycert.crt
-* -key  specify an SSL keyfile (for https mode)
-  * ex:  eps-conduit -key mykeyfile.key
+### Flags
+
+| Flag  | Description                                       | Example Usage                             |
+| ----- | ------------------------------------------------- | ----------------------------------------- |
+| -b    | specify a list of backend hosts                   | eps-conduit -b "10.2.8.1, 10.2.8.2"       |
+| -bind | specify what port to bind to (defaults to 8000)   | eps-conduit -bind 80                      |
+| -mode | specifies what mode to use (http or https)        | eps-conduit -mode https                   |
+| -cert | specify an SSL cert file (for https mode)         | eps-conduit -cert mycert.crt              |
+| -key  | specify an SSL keyfile (for https mode)           | eps-conduit -key mykeyfile.key            |
+| -log  | specify a path to store access logs               | eps-conduit -log /var/log/eps-conduit.log |

--- a/conduit.conf
+++ b/conduit.conf
@@ -3,3 +3,4 @@ bind = "8000"
 backends = [ "127.0.0.1:8001", "127.0.0.1:8002" ]
 certFile = "cert"
 keyFile = "cert"
+accessLog = "/var/log/eps-conduit.log"

--- a/log.go
+++ b/log.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+// customWriter is a thin wrapper around http.ResponseWriter which captures
+// the status code and content length in a way that a normal writer cannot
+type customWriter struct {
+	http.ResponseWriter
+	status int
+	length int
+}
+
+// StatusCode returns the response's status code
+func (w *customWriter) StatusCode() int {
+	return w.status
+}
+
+// ContentLength returns the response's body length
+func (w *customWriter) ContentLength() int {
+	return w.length
+}
+
+// WriteHeader satisfies the http.ResponseWriter interface
+func (w *customWriter) WriteHeader(status int) {
+	w.status = status
+	w.ResponseWriter.WriteHeader(status)
+}
+
+// Write satisfies the http.ResponseWriter interface
+func (w *customWriter) Write(b []byte) (int, error) {
+	if w.status == 0 {
+		w.status = 200
+	}
+	w.length = len(b)
+	return w.ResponseWriter.Write(b)
+}
+
+// LoggingMiddleware intercepts a handler writing the relevant information of
+// the request to the access log file
+func LoggingMiddleware(fn http.HandlerFunc) http.HandlerFunc {
+	file, err := os.OpenFile(config.AccessLog, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	if err != nil {
+		log.Fatal("Could not open log file:", err)
+	}
+	logger := log.New(file, "", 0)
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		writer := customWriter{w, 0, 0}
+		start := time.Now()
+		fn(&writer, r)
+		end := time.Now()
+
+		logger.Printf(
+			"%s %d %s %s %s %d %d %s %d \"%s %s%s %s\" \"%s\"",
+			end.Format(time.RFC3339),
+			config.NextHost,
+			config.Backends[config.NextHost],
+			r.RemoteAddr,
+			end.Sub(start),
+			r.ContentLength,
+			writer.ContentLength(),
+			r.Proto,
+			writer.StatusCode(),
+			r.Method,
+			r.Host,
+			r.RequestURI,
+			r.Proto,
+			r.UserAgent(),
+		)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -25,13 +25,14 @@ var bind = flag.String("bind", "", "The port the load balancer should listen to"
 var mode = flag.String("mode", "", "Balancing Mode")
 var certFile = flag.String("cert", "", "Path to rsa private key")
 var keyFile = flag.String("key", "", "Path to rsa public key")
+var accessLog = flag.String("log", "", "Path to store access logs")
 
 func main() {
-
 	flag.Parse()
 	config := GetConfig(*configFile)
+
 	// send requests to proxies via config.handle
-	http.HandleFunc("/", config.handle)
+	http.HandleFunc("/", LoggingMiddleware(config.handle))
 
 	// Start the http(s) listener depending on user's selected mode
 	if config.Mode == "http" {


### PR DESCRIPTION
This Pull Request satisfies #45.

I have tested this with both the default config file and a flag and it seems to work so I'm pushing for critique and hopeful approval into the project.

Access logs can be specified by adding the `accessLog` line to the `conduit.conf` file or by using the `-log` flag with a file path. If the file doesn't exist, the application will attempt to create it. A fatal error will occur if the log is not writable. This brings up my first question: should we fail on log error or should the application continue and simply not log information? Perhaps by default it can log to stdout but I haven't decided where I stand yet.

**To Test**
- Run the vagrant box as usual (rebuilding the code to receive these changes)
- Change directories to `/vagrant/bin` and run `./eps-conduit` without any flags
- If it fails due to permissions, you can use `sudo` to create the file in `/var/log/`
- Run `tail -f /var/log/eps-conduit.log` in another terminal session
- Navigate your browser to `127.0.0.1:8000` and see that the log populates
- Stop the conduit and run it again this time with a flag `./eps-conduit -log/tmp/test.log` and tail this file and see that it writes there

**Format**

The format chosen is similar to Amazon ELB logs where each line will look like:

```
timestamp load_balancer_id load_balancer_ip:port client_ip:port request_latency request_bytes response_bytes protocol status_code "request_string" "user_agent"
```

An example is:

```
2016-02-08T03:50:21Z 1 127.0.0.1:8002 10.0.2.2:50348 1.262676ms 0 62 HTTP/1.1 200 "GET 127.0.0.1:8000/ HTTP/1.1" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.106 Safari/537.36"
```

Let me know if we should make some changes or if this is an acceptable logging mechanism! 
